### PR TITLE
Reuse UDP socket while flushing stats

### DIFF
--- a/backends/gossip_girl.js
+++ b/backends/gossip_girl.js
@@ -6,6 +6,7 @@ function GossipGirl(startupTime, config, emitter) {
   self.config = config.gossip_girl || []
   self.statsd_config = config
   self.ignorable = [ "statsd.packets_received", "statsd.bad_lines_seen", "statsd.packet_process_time" ]
+  self.sock = dgram.createSocket("udp4")
 
   emitter.on('flush', function(time_stamp, metrics) { self.process(time_stamp, metrics); })
 }
@@ -34,7 +35,6 @@ GossipGirl.prototype.process = function(time_stamp, metrics) {
     timers:   { data: metrics.timers,   suffix: "ms", name: "timer" }
   }
 
-  self.sock = dgram.createSocket("udp4")
   for (var i = 0; i < hosts.length; i++) {
     for (type in stats_map) {
       stats = stats_map[type]
@@ -57,6 +57,11 @@ GossipGirl.prototype.process = function(time_stamp, metrics) {
     }
   }
 }
+
+GossipGirl.prototype.stop = function(cb) {
+  this.sock.close();
+  cb();
+};
 
 exports.init = function(startupTime, config, events) {
   var instance = new GossipGirl(startupTime, config, events)


### PR DESCRIPTION
Otherwise after each flush total process connection count is constantly increasing and is never cleaned up:

```
$ ps aux | grep statsd
statsd   29807 38.3  0.0 1253624 35228 ?       Ssl  10:58   8:46 statsd /opt/statsd/config_buffering_repeater.js
$ lsof -p 29807 | wc -l
1423
$ lsof -p 29807 | tail -n 10
statsd  29807 statsd 1383u     IPv4         1586135868      0t0        UDP *:40056
statsd  29807 statsd 1384u     IPv4         1586147589      0t0        UDP *:55934
statsd  29807 statsd 1385u     IPv4         1586135879      0t0        UDP *:45790
statsd  29807 statsd 1386u     IPv4         1586146873      0t0        UDP *:37203
statsd  29807 statsd 1387u     IPv4         1586150537      0t0        UDP *:49581
statsd  29807 statsd 1388u     IPv4         1586146884      0t0        UDP *:33677
statsd  29807 statsd 1389u     IPv4         1586146885      0t0        UDP *:59865
statsd  29807 statsd 1390u     IPv4         1586150558      0t0        UDP *:42280
statsd  29807 statsd 1391u     IPv4         1586150575      0t0        UDP *:45595
statsd  29807 statsd 1392u     IPv4         1586149498      0t0        UDP *:45977
```


@obradovic 