### PR TITLE
[DEP0005] DeprecationWarning: Buffer() is deprecated due to security …

### DIFF
--- a/backends/gossip_girl.js
+++ b/backends/gossip_girl.js
@@ -20,7 +20,7 @@ GossipGirl.prototype.gossip = function(packet, host, port) {
 }
 
 GossipGirl.prototype.format = function (key, value, suffix) {
-  return new Buffer("'" + key + "':" + value + "|" + suffix)
+  return Buffer.from("'" + key + "':" + value + "|" + suffix)
 }
 
 GossipGirl.prototype.process = function(time_stamp, metrics) {


### PR DESCRIPTION
…and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.